### PR TITLE
Add FID import support

### DIFF
--- a/web/src/app/api/neynar/fids/route.ts
+++ b/web/src/app/api/neynar/fids/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { redisCache } from '@/lib/redis';
+
+const NEYNAR_API_KEY = process.env.NEYNAR_API_KEY;
+
+if (!NEYNAR_API_KEY) {
+  console.error('NEYNAR_API_KEY is not set');
+}
+
+interface NeynarUser {
+  fid: number;
+  username: string;
+  display_name: string;
+  custody_address: string;
+  verified_addresses?: {
+    eth_addresses?: string[];
+    primary?: {
+      eth_address?: string;
+    };
+  };
+}
+
+interface UserResponse {
+  result?: { user: NeynarUser };
+  user?: NeynarUser;
+}
+
+export async function POST(request: Request) {
+  if (!NEYNAR_API_KEY) {
+    return NextResponse.json({ error: 'NEYNAR_API_KEY is not configured' }, { status: 500 });
+  }
+
+  try {
+    const body = await request.json();
+    let { fids } = body as { fids: any };
+
+    if (!Array.isArray(fids)) {
+      return NextResponse.json({ error: 'FIDs must be an array' }, { status: 400 });
+    }
+
+    const fidNumbers = [...new Set(fids.map((f: any) => Number(f)).filter(n => !isNaN(n)))];
+
+    if (fidNumbers.length === 0) {
+      return NextResponse.json({ error: 'No valid FIDs provided' }, { status: 400 });
+    }
+
+    const addresses: string[] = [];
+
+    for (const fid of fidNumbers) {
+      const cacheKey = `neynar:fid:${fid}`;
+      let user = await redisCache.get<NeynarUser>(cacheKey);
+
+      if (!user) {
+        const response = await fetch(`https://api.neynar.com/v2/farcaster/user?fid=${fid}`, {
+          headers: { 'x-api-key': NEYNAR_API_KEY },
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error('Neynar API error:', errorText);
+
+          if (response.status === 404) {
+            continue; // skip unknown fid
+          }
+
+          return NextResponse.json({ error: `Failed to fetch user for fid ${fid}` }, { status: response.status });
+        }
+
+        const data: UserResponse = await response.json();
+        user = data.result?.user || data.user;
+
+        if (user) {
+          await redisCache.set(cacheKey, user, 3600);
+        }
+      }
+
+      if (user) {
+        const ethAddress = user.verified_addresses?.primary?.eth_address || user.custody_address;
+        if (ethAddress) {
+          addresses.push(ethAddress);
+        }
+      }
+    }
+
+    return NextResponse.json({ addresses });
+  } catch (error) {
+    console.error('Error in fid address fetch:', error);
+    return NextResponse.json({ error: 'Failed to fetch addresses' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/neynar/fids/route.ts
+++ b/web/src/app/api/neynar/fids/route.ts
@@ -60,13 +60,13 @@ export async function POST(request: Request) {
     }
 
     if (missingFids.length > 0) {
-      const response = await fetch('https://api.neynar.com/v2/farcaster/user/bulk', {
-        method: 'POST',
+      const url = new URL('https://api.neynar.com/v2/farcaster/user/bulk');
+      url.searchParams.set('fids', missingFids.join(','));
+
+      const response = await fetch(url.toString(), {
         headers: {
           'x-api-key': NEYNAR_API_KEY,
-          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ fids: missingFids }),
       });
 
       if (!response.ok) {

--- a/web/src/app/api/neynar/fids/route.ts
+++ b/web/src/app/api/neynar/fids/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
     }
 
     if (missingFids.length > 0) {
-      const url = new URL('https://api.neynar.com/v2/farcaster/user/bulk');
+      const url = new URL('https://api.neynar.com/v2/farcaster/user/bulk/');
       url.searchParams.set('fids', missingFids.join(','));
 
       const response = await fetch(url.toString(), {

--- a/web/src/components/ImportFidsModal.tsx
+++ b/web/src/components/ImportFidsModal.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { FC, useState } from "react";
+
+interface ImportFidsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (addresses: string[]) => void;
+}
+
+export const ImportFidsModal: FC<ImportFidsModalProps> = ({ isOpen, onClose, onImport }) => {
+  const [fidInput, setFidInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleImport = async () => {
+    const fids = fidInput
+      .split(/[\n,]/)
+      .map((f) => f.trim())
+      .filter((f) => f.length > 0);
+
+    if (fids.length === 0) {
+      setError("Please enter at least one FID");
+      return;
+    }
+
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/neynar/fids", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ fids }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to fetch addresses");
+      }
+
+      const addresses = (data.addresses || []) as string[];
+      if (addresses.length > 0) {
+        onImport(addresses);
+        handleClose();
+      } else {
+        setError("No addresses found for the provided FIDs");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch addresses");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setFidInput("");
+    setError("");
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={handleClose} />
+      <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
+        <div
+          className="bg-zinc-900 rounded-lg max-w-md w-full p-6 relative"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            onClick={handleClose}
+            className="absolute top-4 right-4 text-zinc-400 hover:text-zinc-200 transition-colors"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-bold mb-4">Import FIDs</h2>
+          <p className="text-sm text-zinc-400 mb-3">
+            Paste Farcaster FIDs (comma or newline separated) to fetch their Ethereum addresses.
+          </p>
+          <textarea
+            className="w-full h-32 px-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg focus:outline-none focus:border-purple-500 mb-3"
+            placeholder="123\n456\n789"
+            value={fidInput}
+            onChange={(e) => setFidInput(e.target.value)}
+          />
+          {error && <div className="text-red-500 text-sm mb-3">{error}</div>}
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2 text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleImport}
+              disabled={isLoading || fidInput.trim().length === 0}
+              className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-zinc-600 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
+            >
+              {isLoading ? "Loading..." : "Import"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/web/src/components/manage/SelectRandomWinner.tsx
+++ b/web/src/components/manage/SelectRandomWinner.tsx
@@ -9,6 +9,7 @@ import { toast } from "react-toastify";
 import { ImportSearchedFarcasterUsers } from "../ImportSearchedFarcasterUsers";
 import { ImportCastLikersModal } from "../ImportCastLikersModal";
 import { ImportSnapshotVotersModal } from "../ImportSnapshotVotersModal";
+import { ImportFidsModal } from "../ImportFidsModal";
 
 const BUFFER_PERCENTAGE = 300n; // 3x buffer
 
@@ -27,6 +28,7 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isCastLikersModalOpen, setIsCastLikersModalOpen] = useState(false);
   const [isSnapshotModalOpen, setIsSnapshotModalOpen] = useState(false);
+  const [isFidsModalOpen, setIsFidsModalOpen] = useState(false);
 
   const addresses = useMemo(() => {
     return eligibleAddresses
@@ -93,6 +95,12 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
             Search Farcaster Users
           </button>
           <button
+            onClick={() => setIsFidsModalOpen(true)}
+            className="px-4 py-2 bg-purple-500 hover:bg-purple-600 text-white rounded-lg transition-colors text-sm font-medium"
+          >
+            Import FIDs
+          </button>
+          <button
             onClick={() => setIsCastLikersModalOpen(true)}
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
           >
@@ -150,6 +158,12 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
       <ImportSearchedFarcasterUsers
         isOpen={isImportModalOpen}
         onClose={() => setIsImportModalOpen(false)}
+        onImport={handleAddressesImported}
+      />
+
+      <ImportFidsModal
+        isOpen={isFidsModalOpen}
+        onClose={() => setIsFidsModalOpen(false)}
         onImport={handleAddressesImported}
       />
 


### PR DESCRIPTION
## Summary
- add API route to fetch addresses from FIDs
- add `ImportFidsModal` component
- hook new modal into random winner management

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684469ad74548331a62155ce05f10b9f