### PR TITLE
Implement multicall for holder filtering

### DIFF
--- a/web/src/app/api/holders/filter/route.ts
+++ b/web/src/app/api/holders/filter/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { redisCache } from '@/lib/redis';
+import { client } from '@/constants/thirdweb';
+import { chain } from '@/constants/chain';
+import { getContract, toUnits } from 'thirdweb';
+import { decimals } from 'thirdweb/extensions/erc20';
+import { isAddress } from 'thirdweb/utils';
+import { createPublicClient, http, erc20Abi } from 'viem';
+import { base } from 'viem/chains';
+
+export const dynamic = 'force-dynamic';
+
+const publicClient = createPublicClient({
+  chain: base,
+  transport: http(),
+});
+
+const CACHE_TTL = 60; // 1 minute
+
+interface FilterRequest {
+  addresses: string[];
+  token: string;
+  amount: string;
+}
+
+export async function POST(req: Request) {
+  try {
+    const { addresses, token, amount } = (await req.json()) as FilterRequest;
+
+    if (!token || !isAddress(token)) {
+      return NextResponse.json({ error: 'Invalid token address' }, { status: 400 });
+    }
+
+    if (!Array.isArray(addresses) || addresses.length === 0) {
+      return NextResponse.json({ error: 'Addresses are required' }, { status: 400 });
+    }
+
+    const validAddresses = addresses.filter(a => isAddress(a)) as `0x${string}`[];
+
+    if (validAddresses.length === 0) {
+      return NextResponse.json({ addresses: [] });
+    }
+
+    const tokenContract = getContract({ client, chain, address: token as `0x${string}` });
+    const tokenDecimals = await decimals({ contract: tokenContract });
+    const amountWei = toUnits(amount || '0', tokenDecimals);
+
+    const filtered: string[] = [];
+
+    const toFetch: { addr: `0x${string}`; cacheKey: string }[] = [];
+    const cachedBalances = new Map<string, string>();
+
+    for (const addr of validAddresses) {
+      const cacheKey = `holder:${token}:${addr.toLowerCase()}`;
+      const balanceStr = await redisCache.get<string>(cacheKey);
+      if (balanceStr) {
+        cachedBalances.set(addr, balanceStr);
+      } else {
+        toFetch.push({ addr, cacheKey });
+      }
+    }
+
+    if (toFetch.length > 0) {
+      const contracts = toFetch.map(({ addr }) => ({
+        address: token as `0x${string}`,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [addr],
+      }));
+
+      const results = await publicClient.multicall({ contracts });
+
+      for (let i = 0; i < results.length; i++) {
+        const { addr, cacheKey } = toFetch[i];
+        const result = results[i];
+        const bal = result.status === 'success' ? (result.result as bigint) : 0n;
+        const balStr = bal.toString();
+        cachedBalances.set(addr, balStr);
+        await redisCache.set(cacheKey, balStr, CACHE_TTL);
+      }
+    }
+
+    for (const addr of validAddresses) {
+      const balStr = cachedBalances.get(addr) ?? '0';
+      if (BigInt(balStr) >= amountWei) {
+        filtered.push(addr);
+      }
+    }
+
+    return NextResponse.json({ addresses: filtered });
+  } catch (error) {
+    console.error('Error filtering holders:', error);
+    return NextResponse.json({ error: 'Failed to filter addresses' }, { status: 500 });
+  }
+}

--- a/web/src/components/FilterHoldersModal.tsx
+++ b/web/src/components/FilterHoldersModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+import { FC, useState } from "react";
+import { isAddress } from "thirdweb/utils";
+
+interface FilterHoldersModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  addresses: string[];
+  onFilter: (addresses: string[]) => void;
+}
+
+export const FilterHoldersModal: FC<FilterHoldersModalProps> = ({ isOpen, onClose, addresses, onFilter }) => {
+  const [tokenAddress, setTokenAddress] = useState("");
+  const [amount, setAmount] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!isOpen) return null;
+
+  const isValidToken = tokenAddress && isAddress(tokenAddress);
+
+  const handleClose = () => {
+    setTokenAddress("");
+    setAmount("");
+    setError("");
+    onClose();
+  };
+
+  const handleFilter = async () => {
+    if (!isValidToken) {
+      setError("Invalid token address");
+      return;
+    }
+    setIsLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/holders/filter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ addresses, token: tokenAddress, amount }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to filter addresses");
+      }
+      onFilter(data.addresses || []);
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to filter addresses");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={handleClose} />
+      <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
+        <div className="bg-zinc-900 rounded-lg max-w-md w-full p-6 relative" onClick={(e) => e.stopPropagation()}>
+          <button onClick={handleClose} className="absolute top-4 right-4 text-zinc-400 hover:text-zinc-200 transition-colors">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-bold mb-4">Filter by Holders</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Token Address</label>
+              <input
+                type="text"
+                placeholder="0x..."
+                value={tokenAddress}
+                onChange={(e) => setTokenAddress(e.target.value)}
+                className="w-full px-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500"
+              />
+              {tokenAddress && !isValidToken && <p className="text-red-500 text-sm mt-1">Invalid address format</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Minimum Amount</label>
+              <input
+                type="number"
+                placeholder="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className="w-full px-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500"
+              />
+            </div>
+            {error && <div className="text-red-500 text-sm">{error}</div>}
+            <div className="flex justify-end gap-3 mt-6">
+              <button type="button" onClick={handleClose} className="px-4 py-2 text-zinc-400 hover:text-zinc-200 transition-colors">
+                Cancel
+              </button>
+              <button
+                onClick={handleFilter}
+                disabled={!isValidToken || isLoading}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-zinc-600 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
+              >
+                {isLoading ? "Filtering..." : "Apply Filter"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/web/src/components/manage/SelectRandomWinner.tsx
+++ b/web/src/components/manage/SelectRandomWinner.tsx
@@ -10,6 +10,7 @@ import { ImportSearchedFarcasterUsers } from "../ImportSearchedFarcasterUsers";
 import { ImportCastLikersModal } from "../ImportCastLikersModal";
 import { ImportSnapshotVotersModal } from "../ImportSnapshotVotersModal";
 import { ImportFidsModal } from "../ImportFidsModal";
+import { FilterHoldersModal } from "../FilterHoldersModal";
 
 const BUFFER_PERCENTAGE = 300n; // 3x buffer
 
@@ -29,6 +30,7 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
   const [isCastLikersModalOpen, setIsCastLikersModalOpen] = useState(false);
   const [isSnapshotModalOpen, setIsSnapshotModalOpen] = useState(false);
   const [isFidsModalOpen, setIsFidsModalOpen] = useState(false);
+  const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
 
   const addresses = useMemo(() => {
     return eligibleAddresses
@@ -120,6 +122,12 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
           onChange={(e) => setEligibleAddresses(e.target.value)}
           className="w-full px-4 py-2 bg-zinc-900 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500 h-32 mb-3"
         />
+        <button
+          onClick={() => setIsFilterModalOpen(true)}
+          className="mb-3 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
+        >
+          Filter by Holders
+        </button>
         <div className="flex justify-end">
           <TransactionButton
             transaction={() => requestWinnerTx}
@@ -178,6 +186,13 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
         onClose={() => setIsSnapshotModalOpen(false)}
         onImport={handleAddressesImported}
       />
+
+      <FilterHoldersModal
+        isOpen={isFilterModalOpen}
+        onClose={() => setIsFilterModalOpen(false)}
+        addresses={addresses}
+        onFilter={(filtered) => setEligibleAddresses(filtered.join("\n"))}
+      />
     </>
   );
-}; 
+};


### PR DESCRIPTION
## Summary
- batch ERC20 balance lookups via viem's `multicall`
- cache balances per address/token for one minute
- store cached balances as strings

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68447fa8e5508331aff632658f80b13e