### PR TITLE
Add Neynar score filtering for raffle addresses

### DIFF
--- a/web/src/app/api/neynar/score/route.ts
+++ b/web/src/app/api/neynar/score/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import { redisCache } from '@/lib/redis';
+
+const NEYNAR_API_KEY = process.env.NEYNAR_API_KEY;
+
+if (!NEYNAR_API_KEY) {
+  console.error('NEYNAR_API_KEY is not set');
+}
+
+interface NeynarUser {
+  fid: number;
+  custody_address: string;
+  score?: number;
+  verified_addresses?: {
+    eth_addresses?: string[];
+    primary?: {
+      eth_address?: string;
+    };
+  };
+}
+
+interface UsersResponse {
+  result?: { users: NeynarUser[] };
+  users?: NeynarUser[];
+}
+
+export async function POST(request: Request) {
+  if (!NEYNAR_API_KEY) {
+    return NextResponse.json({ error: 'NEYNAR_API_KEY is not configured' }, { status: 500 });
+  }
+
+  try {
+    const body = await request.json();
+    let { addresses, minScore } = body as { addresses: any; minScore?: number };
+
+    if (!Array.isArray(addresses)) {
+      return NextResponse.json({ error: 'Addresses must be an array' }, { status: 400 });
+    }
+
+    const uniqueAddresses = [...new Set(
+      addresses
+        .map((a: any) => (typeof a === 'string' ? a.trim().toLowerCase() : ''))
+        .filter((a: string) => a.length > 0)
+    )];
+
+    if (uniqueAddresses.length === 0) {
+      return NextResponse.json({ error: 'No valid addresses provided' }, { status: 400 });
+    }
+
+    const threshold = typeof minScore === 'number' ? minScore : 0.9;
+
+    const cachedUsers: Record<string, NeynarUser> = {};
+    const missing: string[] = [];
+
+    for (const addr of uniqueAddresses) {
+      const cacheKey = `neynar:address:${addr}`;
+      const cached = await redisCache.get<NeynarUser>(cacheKey);
+      if (cached && typeof cached.score === 'number') {
+        cachedUsers[addr] = cached;
+      } else {
+        missing.push(addr);
+      }
+    }
+
+    if (missing.length > 0) {
+      const url = new URL('https://api.neynar.com/v2/farcaster/user/bulk-by-address');
+      for (const addr of missing) {
+        url.searchParams.append('addresses[]', addr);
+        url.searchParams.append('address_types[]', 'eth');
+      }
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          'x-api-key': NEYNAR_API_KEY,
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Neynar API error:', errorText);
+        return NextResponse.json({ error: 'Failed to fetch users' }, { status: response.status });
+      }
+
+      const data: UsersResponse = await response.json();
+      const users = data.result?.users || data.users || [];
+
+      const fids: number[] = [];
+      const addressToUser: Record<string, NeynarUser> = {};
+      const missingSet = new Set(missing);
+
+      for (const user of users) {
+        const possible = [
+          user.custody_address?.toLowerCase(),
+          ...(user.verified_addresses?.eth_addresses?.map(a => a.toLowerCase()) || []),
+          user.verified_addresses?.primary?.eth_address?.toLowerCase(),
+        ].filter(Boolean) as string[];
+
+        const matched = possible.find((a) => missingSet.has(a));
+        if (matched && typeof user.fid === 'number') {
+          fids.push(user.fid);
+          addressToUser[matched] = user;
+          missingSet.delete(matched);
+        }
+      }
+
+      if (fids.length > 0) {
+        const scoreUrl = new URL('https://api.neynar.com/v2/farcaster/user/bulk');
+        scoreUrl.searchParams.set('fids', fids.join(','));
+
+        const scoreResp = await fetch(scoreUrl.toString(), {
+          headers: {
+            'x-api-key': NEYNAR_API_KEY,
+          },
+        });
+
+        if (!scoreResp.ok) {
+          const errorText = await scoreResp.text();
+          console.error('Neynar score API error:', errorText);
+          return NextResponse.json({ error: 'Failed to fetch scores' }, { status: scoreResp.status });
+        }
+
+        const scoreData: UsersResponse = await scoreResp.json();
+        const scoreUsers = scoreData.result?.users || scoreData.users || [];
+        const scoreMap: Record<number, number> = {};
+        for (const u of scoreUsers) {
+          if (typeof u.fid === 'number') {
+            const score =
+              typeof u.score === 'number'
+                ? u.score
+                : (u as any)?.neynar_profile?.score;
+            scoreMap[u.fid] = score ?? 0;
+          }
+        }
+
+        for (const [addr, user] of Object.entries(addressToUser)) {
+          user.score = scoreMap[user.fid] ?? 0;
+          cachedUsers[addr] = user;
+          await redisCache.set(`neynar:address:${addr}`, user, 3600);
+        }
+      }
+    }
+
+    const filtered = uniqueAddresses.filter((addr) => {
+      const user = cachedUsers[addr];
+      return user && (user.score ?? 0) >= threshold;
+    });
+
+    return NextResponse.json({ addresses: filtered });
+  } catch (error) {
+    console.error('Error filtering by Neynar score:', error);
+    return NextResponse.json({ error: 'Failed to filter addresses' }, { status: 500 });
+  }
+}

--- a/web/src/components/FilterHumansModal.tsx
+++ b/web/src/components/FilterHumansModal.tsx
@@ -1,40 +1,43 @@
 "use client";
 import { FC, useState } from "react";
 
-interface FilterNeynarScoreModalProps {
+interface FilterHumansModalProps {
   isOpen: boolean;
   onClose: () => void;
   addresses: string[];
   onFilter: (addresses: string[]) => void;
 }
 
-export const FilterNeynarScoreModal: FC<FilterNeynarScoreModalProps> = ({ isOpen, onClose, addresses, onFilter }) => {
-  const [minScore, setMinScore] = useState("0.9");
+export const FilterHumansModal: FC<FilterHumansModalProps> = ({ isOpen, onClose, addresses, onFilter }) => {
+  const [humanCertainty, setHumanCertainty] = useState("90");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
   if (!isOpen) return null;
 
-  const isValidScore = minScore && !isNaN(Number(minScore)) && Number(minScore) >= 0 && Number(minScore) <= 1;
+  const isValidPercentage = humanCertainty && !isNaN(Number(humanCertainty)) && Number(humanCertainty) >= 0 && Number(humanCertainty) <= 100;
 
   const handleClose = () => {
-    setMinScore("0.9");
+    setHumanCertainty("90");
     setError("");
     onClose();
   };
 
   const handleFilter = async () => {
-    if (!isValidScore) {
-      setError("Please enter a valid score between 0 and 1");
+    if (!isValidPercentage) {
+      setError("Please enter a valid percentage between 0 and 100");
       return;
     }
     setIsLoading(true);
     setError("");
     try {
+      // Convert percentage to Neynar score (90% -> 0.9)
+      const neynarScore = Number(humanCertainty) / 100;
+      
       const response = await fetch("/api/neynar/score", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ addresses, minScore: Number(minScore) }),
+        body: JSON.stringify({ addresses, minScore: neynarScore }),
       });
       const data = await response.json();
       if (!response.ok) {
@@ -59,27 +62,30 @@ export const FilterNeynarScoreModal: FC<FilterNeynarScoreModalProps> = ({ isOpen
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
-          <h2 className="text-2xl font-bold mb-4">Filter by Neynar Score</h2>
+          <h2 className="text-2xl font-bold mb-4">Filter by Humans</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-zinc-400 mb-2">Minimum Neynar Score</label>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Human Certainty Percentage</label>
               <input
                 type="number"
-                step="0.01"
+                step="1"
                 min="0"
-                max="1"
-                placeholder="0.9"
-                value={minScore}
-                onChange={(e) => setMinScore(e.target.value)}
+                max="100"
+                placeholder="90"
+                value={humanCertainty}
+                onChange={(e) => setHumanCertainty(e.target.value)}
                 className="w-full px-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500"
               />
-              <p className="text-zinc-500 text-sm mt-1">Enter a score between 0 and 1 (e.g., 0.9 for 90%)</p>
-              {minScore && !isValidScore && <p className="text-red-500 text-sm mt-1">Please enter a valid score between 0 and 1</p>}
+              <p className="text-zinc-500 text-sm mt-1">Enter a percentage between 0 and 100 (e.g., 90 for 90% certainty)</p>
+              {humanCertainty && !isValidPercentage && <p className="text-red-500 text-sm mt-1">Please enter a valid percentage between 0 and 100</p>}
             </div>
             <div className="bg-zinc-800/50 rounded-lg p-3">
               <p className="text-sm text-zinc-400">
-                <strong className="text-zinc-200">Neynar Score:</strong> A reputation score based on Farcaster activity, 
-                engagement, and social connections. Higher scores indicate more established and active users.
+                <strong className="text-zinc-200">Human Detection:</strong> Filters addresses based on Farcaster activity patterns 
+                to identify likely human users. Higher percentages mean more certainty that users are real humans rather than bots.
+              </p>
+              <p className="text-xs text-zinc-500 mt-2">
+                Note: Addresses without Farcaster activity will be filtered out as we cannot determine if they are human or not.
               </p>
             </div>
             {error && <div className="text-red-500 text-sm">{error}</div>}
@@ -89,7 +95,7 @@ export const FilterNeynarScoreModal: FC<FilterNeynarScoreModalProps> = ({ isOpen
               </button>
               <button
                 onClick={handleFilter}
-                disabled={!isValidScore || isLoading}
+                disabled={!isValidPercentage || isLoading}
                 className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-zinc-600 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
               >
                 {isLoading ? "Filtering..." : "Apply Filter"}

--- a/web/src/components/FilterNeynarScoreModal.tsx
+++ b/web/src/components/FilterNeynarScoreModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { FC, useState } from "react";
+
+interface FilterNeynarScoreModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  addresses: string[];
+  onFilter: (addresses: string[]) => void;
+}
+
+export const FilterNeynarScoreModal: FC<FilterNeynarScoreModalProps> = ({ isOpen, onClose, addresses, onFilter }) => {
+  const [minScore, setMinScore] = useState("0.9");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!isOpen) return null;
+
+  const isValidScore = minScore && !isNaN(Number(minScore)) && Number(minScore) >= 0 && Number(minScore) <= 1;
+
+  const handleClose = () => {
+    setMinScore("0.9");
+    setError("");
+    onClose();
+  };
+
+  const handleFilter = async () => {
+    if (!isValidScore) {
+      setError("Please enter a valid score between 0 and 1");
+      return;
+    }
+    setIsLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/neynar/score", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ addresses, minScore: Number(minScore) }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to filter addresses");
+      }
+      onFilter(data.addresses || []);
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to filter addresses");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={handleClose} />
+      <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
+        <div className="bg-zinc-900 rounded-lg max-w-md w-full p-6 relative" onClick={(e) => e.stopPropagation()}>
+          <button onClick={handleClose} className="absolute top-4 right-4 text-zinc-400 hover:text-zinc-200 transition-colors">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-bold mb-4">Filter by Neynar Score</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Minimum Neynar Score</label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                max="1"
+                placeholder="0.9"
+                value={minScore}
+                onChange={(e) => setMinScore(e.target.value)}
+                className="w-full px-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500"
+              />
+              <p className="text-zinc-500 text-sm mt-1">Enter a score between 0 and 1 (e.g., 0.9 for 90%)</p>
+              {minScore && !isValidScore && <p className="text-red-500 text-sm mt-1">Please enter a valid score between 0 and 1</p>}
+            </div>
+            <div className="bg-zinc-800/50 rounded-lg p-3">
+              <p className="text-sm text-zinc-400">
+                <strong className="text-zinc-200">Neynar Score:</strong> A reputation score based on Farcaster activity, 
+                engagement, and social connections. Higher scores indicate more established and active users.
+              </p>
+            </div>
+            {error && <div className="text-red-500 text-sm">{error}</div>}
+            <div className="flex justify-end gap-3 mt-6">
+              <button type="button" onClick={handleClose} className="px-4 py-2 text-zinc-400 hover:text-zinc-200 transition-colors">
+                Cancel
+              </button>
+              <button
+                onClick={handleFilter}
+                disabled={!isValidScore || isLoading}
+                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-zinc-600 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
+              >
+                {isLoading ? "Filtering..." : "Apply Filter"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/web/src/components/manage/SelectRandomWinner.tsx
+++ b/web/src/components/manage/SelectRandomWinner.tsx
@@ -126,12 +126,17 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
           </button>
         </div>
 
-        <textarea
-          placeholder="0x1234...&#10;0x5678...&#10;0xabcd..."
-          value={eligibleAddresses}
-          onChange={(e) => setEligibleAddresses(e.target.value)}
-          className="w-full px-4 py-2 bg-zinc-900 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500 h-32 mb-3"
-        />
+        <div className="relative mb-3">
+          <textarea
+            placeholder="0x1234...&#10;0x5678...&#10;0xabcd..."
+            value={eligibleAddresses}
+            onChange={(e) => setEligibleAddresses(e.target.value)}
+            className="w-full px-4 py-2 bg-zinc-900 border border-zinc-700 rounded-lg focus:outline-none focus:border-blue-500 h-32 pr-20"
+          />
+          <div className="absolute bottom-2 right-2 text-xs text-zinc-500 bg-zinc-900/80 px-2 py-1 rounded">
+            {addresses.length} address{addresses.length !== 1 ? 'es' : ''}
+          </div>
+        </div>
         <div className="flex flex-col sm:flex-row gap-2 mb-3">
           <button
             onClick={() => setIsFilterModalOpen(true)}

--- a/web/src/components/manage/SelectRandomWinner.tsx
+++ b/web/src/components/manage/SelectRandomWinner.tsx
@@ -12,7 +12,7 @@ import { ImportCastQuotesModal } from "../ImportCastQuotesModal";
 import { ImportSnapshotVotersModal } from "../ImportSnapshotVotersModal";
 import { ImportFidsModal } from "../ImportFidsModal";
 import { FilterHoldersModal } from "../FilterHoldersModal";
-import { FilterNeynarScoreModal } from "../FilterNeynarScoreModal";
+import { FilterHumansModal } from "../FilterHumansModal";
 
 const BUFFER_PERCENTAGE = 300n; // 3x buffer
 
@@ -34,7 +34,7 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
   const [isSnapshotModalOpen, setIsSnapshotModalOpen] = useState(false);
   const [isFidsModalOpen, setIsFidsModalOpen] = useState(false);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
-  const [isNeynarFilterModalOpen, setIsNeynarFilterModalOpen] = useState(false);
+  const [isHumansFilterModalOpen, setIsHumansFilterModalOpen] = useState(false);
 
   const addresses = useMemo(() => {
     return eligibleAddresses
@@ -140,10 +140,10 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
             Filter by Holders
           </button>
           <button
-            onClick={() => setIsNeynarFilterModalOpen(true)}
+            onClick={() => setIsHumansFilterModalOpen(true)}
             className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors text-sm font-medium"
           >
-            Filter by Neynar Score
+            Filter by Humans
           </button>
         </div>
         <div className="flex justify-end">
@@ -218,9 +218,9 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
         onFilter={(filtered) => setEligibleAddresses(filtered.join("\n"))}
       />
 
-      <FilterNeynarScoreModal
-        isOpen={isNeynarFilterModalOpen}
-        onClose={() => setIsNeynarFilterModalOpen(false)}
+      <FilterHumansModal
+        isOpen={isHumansFilterModalOpen}
+        onClose={() => setIsHumansFilterModalOpen(false)}
         addresses={addresses}
         onFilter={(filtered) => setEligibleAddresses(filtered.join("\n"))}
       />

--- a/web/src/components/manage/SelectRandomWinner.tsx
+++ b/web/src/components/manage/SelectRandomWinner.tsx
@@ -12,6 +12,7 @@ import { ImportCastQuotesModal } from "../ImportCastQuotesModal";
 import { ImportSnapshotVotersModal } from "../ImportSnapshotVotersModal";
 import { ImportFidsModal } from "../ImportFidsModal";
 import { FilterHoldersModal } from "../FilterHoldersModal";
+import { FilterNeynarScoreModal } from "../FilterNeynarScoreModal";
 
 const BUFFER_PERCENTAGE = 300n; // 3x buffer
 
@@ -33,7 +34,7 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
   const [isSnapshotModalOpen, setIsSnapshotModalOpen] = useState(false);
   const [isFidsModalOpen, setIsFidsModalOpen] = useState(false);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
-  const [isNeynarFiltering, setIsNeynarFiltering] = useState(false);
+  const [isNeynarFilterModalOpen, setIsNeynarFilterModalOpen] = useState(false);
 
   const addresses = useMemo(() => {
     return eligibleAddresses
@@ -139,31 +140,10 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
             Filter by Holders
           </button>
           <button
-            onClick={async () => {
-              if (addresses.length === 0) return;
-              setIsNeynarFiltering(true);
-              try {
-                const response = await fetch("/api/neynar/score", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ addresses, minScore: 0.9 }),
-                });
-                const data = await response.json();
-                if (!response.ok) {
-                  throw new Error(data.error || "Failed to filter addresses");
-                }
-                setEligibleAddresses(data.addresses.join("\n"));
-              } catch (err) {
-                console.error("Error filtering by Neynar score:", err);
-                toast.error("Failed to filter by Neynar score");
-              } finally {
-                setIsNeynarFiltering(false);
-              }
-            }}
-            disabled={isNeynarFiltering}
-            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-zinc-600 disabled:opacity-50 text-white rounded-lg transition-colors text-sm font-medium"
+            onClick={() => setIsNeynarFilterModalOpen(true)}
+            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors text-sm font-medium"
           >
-            {isNeynarFiltering ? "Filtering..." : "Require .9 Neynar score or higher"}
+            Filter by Neynar Score
           </button>
         </div>
         <div className="flex justify-end">
@@ -234,6 +214,13 @@ export const SelectRandomWinner: FC<SelectRandomWinnerProps> = ({
       <FilterHoldersModal
         isOpen={isFilterModalOpen}
         onClose={() => setIsFilterModalOpen(false)}
+        addresses={addresses}
+        onFilter={(filtered) => setEligibleAddresses(filtered.join("\n"))}
+      />
+
+      <FilterNeynarScoreModal
+        isOpen={isNeynarFilterModalOpen}
+        onClose={() => setIsNeynarFilterModalOpen(false)}
         addresses={addresses}
         onFilter={(filtered) => setEligibleAddresses(filtered.join("\n"))}
       />

--- a/web/src/types/neynar.ts
+++ b/web/src/types/neynar.ts
@@ -1,0 +1,46 @@
+export interface NeynarUser {
+  object: string;
+  fid: number;
+  username: string;
+  display_name: string;
+  pfp_url: string;
+  custody_address: string;
+  pro?: {
+    status: string;
+    subscribed_at: string;
+    expires_at: string;
+  };
+  profile?: {
+    bio?: {
+      text: string;
+    };
+  };
+  follower_count: number;
+  following_count: number;
+  verifications: string[];
+  verified_addresses: {
+    eth_addresses: string[];
+    sol_addresses?: string[];
+    primary: {
+      eth_address: string;
+      sol_address?: string;
+    };
+  };
+  auth_addresses: Array<{
+    address: string;
+    app: {
+      object: string;
+      fid: number;
+    };
+  }>;
+  verified_accounts: Array<{
+    platform: string;
+    username: string;
+  }>;
+  power_badge: boolean;
+  experimental?: {
+    neynar_user_score: number;
+    deprecation_notice: string;
+  };
+  score: number;
+}


### PR DESCRIPTION
## Summary
- add API route to filter addresses based on Neynar score
- add UI control to require addresses with 0.9+ Neynar score when picking a winner
- fix Neynar score lookup to use bulk-by-address endpoint
- fetch user scores separately and map results to input addresses so valid users remain
- correct query parameters for Neynar bulk user and score requests so valid users are returned
- use bulk user endpoint for score retrieval and parse nested score field

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa8742788331bf4d207be578669f